### PR TITLE
Expand progression with prestige upgrades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,12 @@
 import { motion } from "framer-motion";
 import GeneratorList from "./components/GeneratorList";
+import AutomationPanel from "./components/AutomationPanel";
+import MilestonesPanel from "./components/MilestonesPanel";
 import OfflineGainToast from "./components/OfflineGainToast";
 import PrestigePanel from "./components/PrestigePanel";
+import PrestigeUpgradePanel from "./components/PrestigeUpgradePanel";
 import Ring from "./components/Ring";
+import UpgradePanel from "./components/UpgradePanel";
 import { GameProvider, useGame } from "./game/GameProvider";
 import { format } from "./utils/format";
 
@@ -82,10 +86,61 @@ export default function App() {
           </motion.section>
 
           <motion.section
-            className="rounded-3xl border border-amber-500/30 bg-amber-500/10 p-5 shadow-2xl shadow-amber-900/20 backdrop-blur card-glow"
+            className="rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-5 shadow-2xl shadow-emerald-900/20 backdrop-blur card-glow"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.08 }}
+          >
+            <h2 className="font-semibold uppercase tracking-wider text-emerald-200">Upgrades</h2>
+            <div className="mt-4">
+              <UpgradePanel />
+            </div>
+          </motion.section>
+
+          <motion.section
+            className="rounded-3xl border border-fuchsia-500/30 bg-fuchsia-500/10 p-5 shadow-2xl shadow-fuchsia-900/20 backdrop-blur card-glow"
             initial={{ opacity: 0, y: 30 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.45, ease: "easeOut", delay: 0.1 }}
+          >
+            <h2 className="font-semibold uppercase tracking-wider text-fuchsia-200">Milestones</h2>
+            <div className="mt-4">
+              <MilestonesPanel />
+            </div>
+          </motion.section>
+
+          <motion.section
+            className="rounded-3xl border border-cyan-500/30 bg-cyan-500/10 p-5 shadow-2xl shadow-cyan-900/20 backdrop-blur card-glow"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.12 }}
+          >
+            <h2 className="font-semibold uppercase tracking-wider text-cyan-200">Automation</h2>
+            <div className="mt-4">
+              <AutomationPanel />
+            </div>
+          </motion.section>
+
+          <motion.section
+            className="rounded-3xl border border-rose-500/30 bg-rose-500/10 p-5 shadow-2xl shadow-rose-900/20 backdrop-blur card-glow"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.13 }}
+          >
+            <h2 className="font-semibold uppercase tracking-wider text-rose-200">Prestige Upgrades</h2>
+            <p className="mt-1 text-xs uppercase tracking-[0.3em] text-rose-100/70">
+              Spend prestige for permanent boosts that persist through every reset.
+            </p>
+            <div className="mt-4">
+              <PrestigeUpgradePanel />
+            </div>
+          </motion.section>
+
+          <motion.section
+            className="rounded-3xl border border-amber-500/30 bg-amber-500/10 p-5 shadow-2xl shadow-amber-900/20 backdrop-blur card-glow"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut", delay: 0.16 }}
           >
             <PrestigePanel />
           </motion.section>

--- a/src/components/AutomationPanel.tsx
+++ b/src/components/AutomationPanel.tsx
@@ -1,0 +1,189 @@
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
+import { GENERATORS, MILESTONES, PRESTIGE_UPGRADES, UPGRADES } from "../game/config";
+import { useGame } from "../game/GameProvider";
+import { format } from "../utils/format";
+
+type AutoDisplay = {
+  id: string;
+  label: string;
+  description: string;
+  interval: number;
+  generatorName: string;
+  source:
+    | { kind: "upgrade"; id: string; name: string; cost: number; unlockAt?: number }
+    | { kind: "milestone"; id: string; name: string; threshold: number }
+    | { kind: "prestigeUpgrade"; id: string; name: string; cost: number; unlockAtPrestige?: number; unlockAtTotal?: number };
+};
+
+const autoDisplays: AutoDisplay[] = (() => {
+  const seen = new Set<string>();
+  const entries: AutoDisplay[] = [];
+
+  for (const upgrade of UPGRADES) {
+    for (const effect of upgrade.effects) {
+      if (effect.kind !== "autoBuyer" || seen.has(effect.target)) continue;
+      const generatorName = GENERATORS.find(g => g.id === effect.target)?.name ?? effect.target;
+      entries.push({
+        id: effect.target,
+        label: effect.label,
+        description: effect.description,
+        interval: effect.interval,
+        generatorName,
+        source: { kind: "upgrade", id: upgrade.id, name: upgrade.name, cost: upgrade.cost, unlockAt: upgrade.unlockAt },
+      });
+      seen.add(effect.target);
+    }
+  }
+
+  for (const milestone of MILESTONES) {
+    for (const effect of milestone.effects) {
+      if (effect.kind !== "autoBuyer" || seen.has(effect.target)) continue;
+      const generatorName = GENERATORS.find(g => g.id === effect.target)?.name ?? effect.target;
+      entries.push({
+        id: effect.target,
+        label: effect.label,
+        description: effect.description,
+        interval: effect.interval,
+        generatorName,
+        source: { kind: "milestone", id: milestone.id, name: milestone.name, threshold: milestone.threshold },
+      });
+      seen.add(effect.target);
+    }
+  }
+
+  for (const upgrade of PRESTIGE_UPGRADES) {
+    for (const effect of upgrade.effects) {
+      if (effect.kind !== "autoBuyer" || seen.has(effect.target)) continue;
+      const generatorName = GENERATORS.find(g => g.id === effect.target)?.name ?? effect.target;
+      entries.push({
+        id: effect.target,
+        label: effect.label,
+        description: effect.description,
+        interval: effect.interval,
+        generatorName,
+        source: {
+          kind: "prestigeUpgrade",
+          id: upgrade.id,
+          name: upgrade.name,
+          cost: upgrade.cost,
+          unlockAtPrestige: upgrade.unlockAtPrestige,
+          unlockAtTotal: upgrade.unlockAtTotal,
+        },
+      });
+      seen.add(effect.target);
+    }
+  }
+
+  return entries.sort((a, b) => a.interval - b.interval);
+})();
+
+export default function AutomationPanel() {
+  const { state, dispatch } = useGame();
+
+  if (autoDisplays.length === 0) {
+    return <div className="text-sm text-cyan-100/80">No automation blueprints yet.</div>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {autoDisplays.map((auto, index) => {
+        const entry = state.autoBuyers[auto.id];
+        const unlocked = Boolean(entry);
+        const enabled = entry?.enabled ?? false;
+        const statusLabel = unlocked ? (enabled ? "Running" : "Paused") : "Locked";
+        const statusColor = unlocked ? (enabled ? "text-emerald-200" : "text-amber-200") : "text-slate-300/70";
+
+        let requirement: ReactNode = null;
+        if (!unlocked) {
+          if (auto.source.kind === "upgrade") {
+            const owned = Boolean(state.upgrades[auto.source.id]);
+            const available = (auto.source.unlockAt ?? 0) <= state.totalEnergy;
+            requirement = (
+              <div className="text-[11px] uppercase tracking-[0.3em] text-cyan-100/60">
+                {owned
+                  ? "Purchase upgrade to deploy"
+                  : available
+                    ? `Buy ${auto.source.name} (${format(auto.source.cost)})`
+                    : `Unlocks with ${auto.source.name} at ${format(auto.source.unlockAt ?? 0)} total`}
+              </div>
+            );
+          } else if (auto.source.kind === "prestigeUpgrade") {
+            const owned = Boolean(state.prestigeUpgrades[auto.source.id]);
+            const prestigeOk = (auto.source.unlockAtPrestige ?? 0) <= state.prestige;
+            const totalOk = (auto.source.unlockAtTotal ?? 0) <= state.totalEnergy;
+            requirement = (
+              <div className="text-[11px] uppercase tracking-[0.3em] text-cyan-100/60">
+                {owned
+                  ? "Purchase prestige upgrade to deploy"
+                  : prestigeOk && totalOk
+                    ? `Spend ${auto.source.cost} prestige on ${auto.source.name}`
+                    : `Requires ${auto.source.name} (${auto.source.cost} prestige)`}
+              </div>
+            );
+          } else {
+            const progress = Math.min(state.totalEnergy / auto.source.threshold, 1);
+            requirement = (
+              <div className="text-[11px] uppercase tracking-[0.3em] text-cyan-100/60">
+                {`Reach ${format(auto.source.threshold)} total (${Math.floor(progress * 100)}%)`}
+              </div>
+            );
+          }
+        }
+
+        const containerClasses = [
+          "flex flex-col gap-3 rounded-2xl border bg-cyan-500/10 p-4 shadow-lg shadow-cyan-900/20 backdrop-blur card-glow",
+          unlocked ? "border-cyan-400/40" : "border-cyan-500/30 opacity-75",
+        ].join(" ");
+
+        const buttonClasses = [
+          "group relative overflow-hidden rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] transition",
+          unlocked
+            ? enabled
+              ? "bg-emerald-400 text-slate-900 shadow-lg shadow-emerald-400/30"
+              : "bg-slate-800/60 text-cyan-100"
+            : "bg-slate-800/60 text-cyan-200/40 cursor-not-allowed",
+        ].join(" ");
+
+        return (
+          <motion.div
+            key={auto.id}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, delay: index * 0.05 }}
+            className={containerClasses}
+          >
+            <div>
+              <div className="font-semibold text-cyan-100">
+                {auto.label}
+                <span className="ml-2 text-xs uppercase tracking-[0.3em] text-cyan-200/70">{auto.generatorName}</span>
+              </div>
+              <div className="mt-1 text-sm text-cyan-100/80">{auto.description}</div>
+              <div className="mt-1 text-[11px] uppercase tracking-[0.3em] text-cyan-200/70">Interval: every {auto.interval}s</div>
+              {requirement}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className={`text-xs font-semibold uppercase tracking-[0.3em] ${statusColor}`}>{statusLabel}</span>
+              <motion.button
+                whileTap={unlocked ? { scale: 0.94 } : undefined}
+                onClick={() => unlocked && dispatch({ type: "TOGGLE_AUTOBUYER", id: auto.id, enabled: !enabled })}
+                disabled={!unlocked}
+                className={buttonClasses}
+              >
+                <span className="relative z-10">{enabled ? "Pause" : unlocked ? "Activate" : "Locked"}</span>
+                {unlocked && enabled && (
+                  <motion.span
+                    className="absolute inset-0 translate-y-full bg-gradient-to-r from-emerald-300/60 via-teal-300/60 to-cyan-300/60"
+                    initial={{ y: "100%" }}
+                    animate={{ y: 0 }}
+                    transition={{ duration: 0.22, ease: "easeOut" }}
+                  />
+                )}
+              </motion.button>
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/MilestonesPanel.tsx
+++ b/src/components/MilestonesPanel.tsx
@@ -1,0 +1,76 @@
+import { motion } from "framer-motion";
+import { MILESTONES } from "../game/config";
+import { useGame } from "../game/GameProvider";
+import { format } from "../utils/format";
+
+export default function MilestonesPanel() {
+  const { state, dispatch } = useGame();
+
+  return (
+    <div className="space-y-3">
+      {MILESTONES.map((milestone, index) => {
+        const claimed = Boolean(state.milestones[milestone.id]);
+        const progressRaw = Math.min(state.totalEnergy / milestone.threshold, 1);
+        const canClaim = !claimed && progressRaw >= 1;
+        const progressPercent = Math.floor(progressRaw * 100);
+
+        const containerClasses = [
+          "flex flex-col gap-4 rounded-2xl border bg-fuchsia-500/10 p-4 shadow-lg shadow-fuchsia-900/20 backdrop-blur card-glow",
+          claimed ? "border-fuchsia-400/50" : "border-fuchsia-500/40",
+        ].join(" ");
+
+        const buttonClasses = [
+          "group relative self-start overflow-hidden rounded-xl px-4 py-2 text-sm font-semibold uppercase tracking-[0.3em] transition",
+          claimed
+            ? "bg-fuchsia-500/20 text-fuchsia-100 cursor-not-allowed"
+            : canClaim
+              ? "bg-fuchsia-400 text-slate-900 shadow-lg shadow-fuchsia-400/40"
+              : "bg-slate-800/60 text-fuchsia-200/60 cursor-not-allowed",
+        ].join(" ");
+
+        return (
+          <motion.div
+            key={milestone.id}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, delay: index * 0.05 }}
+            className={containerClasses}
+          >
+            <div>
+              <div className="font-semibold text-fuchsia-100">{milestone.name}</div>
+              <div className="text-[11px] uppercase tracking-[0.3em] text-fuchsia-200/70">Goal: {format(milestone.threshold)} total energy</div>
+              <div className="mt-2 text-sm text-fuchsia-100/90">{milestone.description}</div>
+              <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-white/10">
+                <motion.div
+                  className="h-2 rounded-full bg-gradient-to-r from-fuchsia-400 via-rose-400 to-amber-300"
+                  initial={{ width: 0 }}
+                  animate={{ width: `${progressPercent}%` }}
+                  transition={{ duration: 0.6, ease: "easeOut" }}
+                />
+              </div>
+              <div className="mt-1 text-[11px] uppercase tracking-[0.3em] text-fuchsia-100/70">
+                Progress {format(Math.min(state.totalEnergy, milestone.threshold))}/{format(milestone.threshold)} ({progressPercent}%)
+              </div>
+            </div>
+            <motion.button
+              whileTap={canClaim ? { scale: 0.94 } : undefined}
+              onClick={() => canClaim && dispatch({ type: "CLAIM_MILESTONE", id: milestone.id })}
+              disabled={!canClaim}
+              className={buttonClasses}
+            >
+              <span className="relative z-10">{claimed ? "Claimed" : canClaim ? "Claim Reward" : "Locked"}</span>
+              {canClaim && (
+                <motion.span
+                  className="absolute inset-0 translate-y-full bg-gradient-to-r from-fuchsia-300/60 via-rose-300/60 to-amber-300/60"
+                  initial={{ y: "100%" }}
+                  animate={{ y: 0 }}
+                  transition={{ duration: 0.22, ease: "easeOut" }}
+                />
+              )}
+            </motion.button>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/PrestigeUpgradePanel.tsx
+++ b/src/components/PrestigeUpgradePanel.tsx
@@ -1,0 +1,89 @@
+import { motion } from "framer-motion";
+import { PRESTIGE_UPGRADES } from "../game/config";
+import { useGame } from "../game/GameProvider";
+import { format } from "../utils/format";
+
+export default function PrestigeUpgradePanel() {
+  const { state, dispatch } = useGame();
+
+  return (
+    <div className="space-y-3">
+      {PRESTIGE_UPGRADES.map((upgrade, index) => {
+        const purchased = Boolean(state.prestigeUpgrades[upgrade.id]);
+        const prestigeEnough = state.prestige >= upgrade.cost;
+        const prestigeUnlocked = (upgrade.unlockAtPrestige ?? 0) <= state.prestige;
+        const totalUnlocked = (upgrade.unlockAtTotal ?? 0) <= state.totalEnergy;
+        const unlocked = prestigeUnlocked && totalUnlocked;
+        const canBuy = unlocked && !purchased && prestigeEnough;
+
+        const requirementSegments: string[] = [];
+        if (!prestigeUnlocked && (upgrade.unlockAtPrestige ?? 0) > 0) {
+          requirementSegments.push(`${upgrade.unlockAtPrestige ?? 0} prestige`);
+        }
+        if (!totalUnlocked && (upgrade.unlockAtTotal ?? 0) > 0) {
+          requirementSegments.push(`${format(upgrade.unlockAtTotal ?? 0)} total energy`);
+        }
+        const statusLabel = purchased
+          ? "Purchased"
+          : unlocked
+            ? `Cost: ${upgrade.cost} prestige`
+            : requirementSegments.length > 0
+              ? `Requires ${requirementSegments.join(" & ")}`
+              : `Cost: ${upgrade.cost} prestige`;
+
+        const containerClasses = [
+          "flex flex-col gap-3 rounded-2xl border bg-amber-500/10 p-4 shadow-lg shadow-amber-900/20 backdrop-blur card-glow",
+          purchased ? "border-amber-400/50" : "border-amber-500/30",
+          !unlocked ? "opacity-70" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        const buttonClasses = [
+          "group relative overflow-hidden rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] transition",
+          purchased
+            ? "bg-amber-500/30 text-amber-100 cursor-not-allowed"
+            : canBuy
+              ? "bg-amber-400 text-slate-900 shadow-lg shadow-amber-400/40"
+              : "bg-slate-800/60 text-amber-200/60 cursor-not-allowed",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return (
+          <motion.div
+            key={upgrade.id}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, delay: index * 0.05 }}
+            className={containerClasses}
+          >
+            <div>
+              <div className="font-semibold text-amber-100">{upgrade.name}</div>
+              <div className="text-[11px] uppercase tracking-[0.3em] text-amber-200/70">{statusLabel}</div>
+              <div className="mt-2 text-sm text-amber-100/90">{upgrade.description}</div>
+            </div>
+            <motion.button
+              whileTap={canBuy ? { scale: 0.94 } : undefined}
+              onClick={() => canBuy && dispatch({ type: "BUY_PRESTIGE_UPGRADE", id: upgrade.id })}
+              disabled={!canBuy}
+              className={buttonClasses}
+            >
+              <span className="relative z-10">
+                {purchased ? "Owned" : unlocked ? `Empower • ${upgrade.cost}P` : "Locked"}
+              </span>
+              {canBuy && (
+                <motion.span
+                  className="absolute inset-0 translate-y-full bg-gradient-to-r from-amber-300/60 via-rose-300/60 to-fuchsia-300/60"
+                  initial={{ y: "100%" }}
+                  animate={{ y: 0 }}
+                  transition={{ duration: 0.22, ease: "easeOut" }}
+                />
+              )}
+            </motion.button>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/Ring.tsx
+++ b/src/components/Ring.tsx
@@ -6,7 +6,7 @@ import { format } from "../utils/format";
 type Burst = { id: number; x: number; y: number; value: number };
 
 export default function Ring() {
-  const { state, dispatch, rate } = useGame();
+  const { state, dispatch, rate, clickGain } = useGame();
   const controls = useAnimationControls();
   const [bursts, setBursts] = useState<Burst[]>([]);
   const idRef = useRef(0);
@@ -28,7 +28,7 @@ export default function Ring() {
     const angle = Math.random() * Math.PI * 2;
     const radius = 36 + Math.random() * 20;
     const id = idRef.current++;
-    const value = Number.isFinite(rate) && rate > 0 ? rate : 1;
+    const value = Number.isFinite(clickGain) && clickGain > 0 ? clickGain : 1;
     const burst: Burst = {
       id,
       x: Math.cos(angle) * radius,
@@ -50,6 +50,7 @@ export default function Ring() {
   };
 
   const formattedRate = useMemo(() => format(rate), [rate]);
+  const formattedClick = useMemo(() => format(clickGain), [clickGain]);
 
   return (
     <div className="flex flex-col items-center justify-center">
@@ -88,7 +89,7 @@ export default function Ring() {
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
       >
-        +{formattedRate}/s • Tap for +1 (× prestige)
+        +{formattedRate}/s • Tap +{formattedClick}
       </motion.div>
     </div>
   );

--- a/src/components/UpgradePanel.tsx
+++ b/src/components/UpgradePanel.tsx
@@ -1,0 +1,77 @@
+import { motion } from "framer-motion";
+import { UPGRADES } from "../game/config";
+import { useGame } from "../game/GameProvider";
+import { format } from "../utils/format";
+
+export default function UpgradePanel() {
+  const { state, dispatch } = useGame();
+
+  return (
+    <div className="space-y-3">
+      {UPGRADES.map((upgrade, index) => {
+        const isUnlocked = (upgrade.unlockAt ?? 0) <= state.totalEnergy;
+        const purchased = Boolean(state.upgrades[upgrade.id]);
+        const canAfford = state.energy >= upgrade.cost;
+        const canBuy = isUnlocked && !purchased && canAfford;
+        const statusLabel = purchased
+          ? "Purchased"
+          : isUnlocked
+            ? `Cost: ${format(upgrade.cost)}`
+            : `Unlocks at ${format(upgrade.unlockAt ?? 0)} total`;
+
+        const containerClasses = [
+          "flex flex-col gap-3 rounded-2xl border bg-emerald-500/10 p-4 shadow-lg shadow-emerald-900/20 backdrop-blur card-glow",
+          purchased ? "border-emerald-400/50" : "border-emerald-500/30",
+          !isUnlocked ? "opacity-60" : "",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        const buttonClasses = [
+          "group relative overflow-hidden rounded-xl px-4 py-2 text-sm font-semibold uppercase tracking-[0.3em] transition",
+          purchased
+            ? "bg-emerald-500/30 text-emerald-100 cursor-not-allowed"
+            : canBuy
+              ? "bg-emerald-400 text-slate-900 shadow-lg shadow-emerald-400/40"
+              : "bg-slate-800/60 text-emerald-200/60 cursor-not-allowed",
+        ]
+          .filter(Boolean)
+          .join(" ");
+
+        return (
+          <motion.div
+            key={upgrade.id}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.25, delay: index * 0.05 }}
+            className={containerClasses}
+          >
+            <div>
+              <div className="font-semibold text-emerald-100">{upgrade.name}</div>
+              <div className="text-[11px] uppercase tracking-[0.3em] text-emerald-200/70">{statusLabel}</div>
+              <div className="mt-2 text-sm text-emerald-100/90">{upgrade.description}</div>
+            </div>
+            <motion.button
+              whileTap={canBuy ? { scale: 0.94 } : undefined}
+              onClick={() => canBuy && dispatch({ type: "BUY_UPGRADE", id: upgrade.id })}
+              disabled={!canBuy}
+              className={buttonClasses}
+            >
+              <span className="relative z-10">
+                {purchased ? "Owned" : isUnlocked ? `Upgrade • ${format(upgrade.cost)}` : "Locked"}
+              </span>
+              {canBuy && (
+                <motion.span
+                  className="absolute inset-0 translate-y-full bg-gradient-to-r from-emerald-300/60 via-teal-300/60 to-sky-300/60"
+                  initial={{ y: "100%" }}
+                  animate={{ y: 0 }}
+                  transition={{ duration: 0.22, ease: "easeOut" }}
+                />
+              )}
+            </motion.button>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/game/GameProvider.tsx
+++ b/src/game/GameProvider.tsx
@@ -1,9 +1,29 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useReducer, useRef, useState } from "react";
-import { CLICK_BASE_GAIN, GENERATORS, PRESTIGE_CONVERT, PRESTIGE_REQ } from "./config";
-import type { GeneratorDef } from "./config";
+import {
+  AUTO_BUYER_CONFIG,
+  CLICK_BASE_GAIN,
+  GENERATORS,
+  MILESTONES,
+  PRESTIGE_CONVERT,
+  PRESTIGE_REQ,
+  PRESTIGE_UPGRADES,
+  UPGRADES,
+} from "./config";
+import type { GeneratorDef, Effect } from "./config";
 import { loadGameState, loadGameStateSync, saveGameState } from "../utils/persist";
 
 type GenState = Record<string, { count: number }>;
+type UpgradeState = Record<string, boolean>;
+type MilestoneState = Record<string, boolean>;
+type PrestigeUpgradeState = Record<string, boolean>;
+type AutoBuyerState = Record<string, { enabled: boolean; interval: number; timer: number }>;
+
+type EffectSummary = {
+  clickMultiplier: number;
+  globalGeneratorMultiplier: number;
+  generatorMultipliers: Record<string, number>;
+  prestigeBonus: number;
+};
 
 type State = {
   energy: number;
@@ -11,6 +31,10 @@ type State = {
   gens: GenState;
   prestige: number;     // prestige points
   lastTs: number;       // ms for offline calc
+  upgrades: UpgradeState;
+  milestones: MilestoneState;
+  prestigeUpgrades: PrestigeUpgradeState;
+  autoBuyers: AutoBuyerState;
 };
 
 type Action =
@@ -19,9 +43,16 @@ type Action =
   | { type: "BUY"; id: string }
   | { type: "LOAD"; payload: State }
   | { type: "PRESTIGE" }
+  | { type: "BUY_UPGRADE"; id: string }
+  | { type: "CLAIM_MILESTONE"; id: string }
+  | { type: "BUY_PRESTIGE_UPGRADE"; id: string }
+  | { type: "TOGGLE_AUTOBUYER"; id: string; enabled: boolean }
   ;
 
 const makeDefaultGenState = () => Object.fromEntries(GENERATORS.map(g => [g.id, { count: 0 }]));
+const makeDefaultUpgradeState = () => Object.fromEntries(UPGRADES.map(up => [up.id, false]));
+const makeDefaultMilestoneState = () => Object.fromEntries(MILESTONES.map(m => [m.id, false]));
+const makeDefaultPrestigeUpgradeState = () => Object.fromEntries(PRESTIGE_UPGRADES.map(p => [p.id, false]));
 
 const initial: State = {
   energy: 0,
@@ -29,31 +60,220 @@ const initial: State = {
   gens: makeDefaultGenState(),
   prestige: 0,
   lastTs: Date.now(),
+  upgrades: makeDefaultUpgradeState(),
+  milestones: makeDefaultMilestoneState(),
+  prestigeUpgrades: makeDefaultPrestigeUpgradeState(),
+  autoBuyers: {},
 };
 
-const rateOf = (state: State) => {
-  // global prestige multiplier: 1 + 0.1 per point
-  const mult = 1 + state.prestige * 0.1;
+const summarizeEffects = (flags: { upgrades: UpgradeState; milestones: MilestoneState; prestigeUpgrades: PrestigeUpgradeState }): EffectSummary => {
+  const summary: EffectSummary = {
+    clickMultiplier: 1,
+    globalGeneratorMultiplier: 1,
+    generatorMultipliers: {},
+    prestigeBonus: 0,
+  };
+
+  const collectEffects = (): Effect[] => {
+    const effects: Effect[] = [];
+    for (const up of UPGRADES) {
+      if (flags.upgrades[up.id]) {
+        effects.push(...up.effects);
+      }
+    }
+    for (const milestone of MILESTONES) {
+      if (flags.milestones[milestone.id]) {
+        effects.push(...milestone.effects);
+      }
+    }
+    for (const upgrade of PRESTIGE_UPGRADES) {
+      if (flags.prestigeUpgrades[upgrade.id]) {
+        effects.push(...upgrade.effects);
+      }
+    }
+    return effects;
+  };
+
+  for (const effect of collectEffects()) {
+    if (effect.kind === "multiplier") {
+      if (effect.target === "click") {
+        summary.clickMultiplier *= effect.value;
+      } else if (effect.target === "all") {
+        summary.globalGeneratorMultiplier *= effect.value;
+      } else {
+        summary.generatorMultipliers[effect.target] = (summary.generatorMultipliers[effect.target] ?? 1) * effect.value;
+      }
+    } else if (effect.kind === "prestigeBoost") {
+      summary.prestigeBonus += effect.value;
+    }
+  }
+
+  return summary;
+};
+
+const rateOf = (state: State, effects: EffectSummary) => {
+  const prestigeMult = 1 + (state.prestige + effects.prestigeBonus) * 0.1;
   return GENERATORS.reduce((sum, g) => {
     if (g.id === "click") return sum;
     const c = state.gens[g.id]?.count ?? 0;
-    return sum + c * g.baseRate * mult;
+    const mult = effects.globalGeneratorMultiplier * (effects.generatorMultipliers[g.id] ?? 1);
+    return sum + c * g.baseRate * mult * prestigeMult;
   }, 0);
 };
 
 const nextCost = (def: GeneratorDef, count: number) =>
   Math.ceil(def.baseCost * Math.pow(def.costMult, count));
 
+const applyUnlockEffects = (state: State, effects: Effect[]): State => {
+  let autoBuyers = state.autoBuyers;
+  let changed = false;
+  for (const effect of effects) {
+    if (effect.kind === "autoBuyer") {
+      const existing = autoBuyers[effect.target];
+      const nextEntry = {
+        enabled: existing?.enabled ?? false,
+        timer: existing?.enabled ? existing.timer : 0,
+        interval: effect.interval,
+      };
+      if (!existing || existing.interval !== effect.interval || existing.timer !== nextEntry.timer) {
+        if (!changed) {
+          autoBuyers = { ...autoBuyers };
+          changed = true;
+        }
+        autoBuyers[effect.target] = nextEntry;
+      }
+    }
+  }
+  if (!changed) return state;
+  return { ...state, autoBuyers };
+};
+
+const ensureAutoBuyersForState = (state: State): State => {
+  let current = state;
+  for (const up of UPGRADES) {
+    if (current.upgrades[up.id]) {
+      current = applyUnlockEffects(current, up.effects);
+    }
+  }
+  for (const milestone of MILESTONES) {
+    if (current.milestones[milestone.id]) {
+      current = applyUnlockEffects(current, milestone.effects);
+    }
+  }
+  for (const upgrade of PRESTIGE_UPGRADES) {
+    if (current.prestigeUpgrades[upgrade.id]) {
+      current = applyUnlockEffects(current, upgrade.effects);
+    }
+  }
+  return current;
+};
+
+const resetAutoBuyerTimers = (autoBuyers: AutoBuyerState): AutoBuyerState => {
+  const entries = Object.entries(autoBuyers);
+  if (entries.length === 0) return autoBuyers;
+  const next: AutoBuyerState = {};
+  for (const [id, entry] of entries) {
+    next[id] = { ...entry, timer: 0 };
+  }
+  return next;
+};
+
+const processAutoBuyers = (state: State, energy: number, dt: number) => {
+  if (Object.keys(state.autoBuyers).length === 0) {
+    return { energy, gens: state.gens, autoBuyers: state.autoBuyers };
+  }
+
+  let currentEnergy = energy;
+  let gens = state.gens;
+  let autoBuyers: AutoBuyerState = state.autoBuyers;
+  let autoMutated = false;
+  let gensMutated = false;
+
+  for (const [id, entry] of Object.entries(state.autoBuyers)) {
+    if (!entry) continue;
+    if (!entry.enabled) {
+      if (entry.timer !== 0) {
+        if (!autoMutated) {
+          autoBuyers = { ...autoBuyers };
+          autoMutated = true;
+        }
+        autoBuyers[id] = { ...entry, timer: 0 };
+      }
+      continue;
+    }
+
+    const def = GENERATORS.find(g => g.id === id);
+    if (!def) continue;
+
+    let timer = entry.timer + dt;
+    let workingEnergy = currentEnergy;
+    let workingGens = gens;
+    let localMutated = false;
+
+    while (timer >= entry.interval) {
+      const currentCount = workingGens[id]?.count ?? 0;
+      const cost = nextCost(def, currentCount);
+      if (workingEnergy >= cost) {
+        if (!localMutated) {
+          workingGens = { ...workingGens };
+          localMutated = true;
+        }
+        workingGens[id] = { count: currentCount + 1 };
+        workingEnergy -= cost;
+        timer -= entry.interval;
+      } else {
+        break;
+      }
+    }
+
+    if (localMutated) {
+      gens = workingGens;
+      gensMutated = true;
+      currentEnergy = workingEnergy;
+    }
+
+    if (timer !== entry.timer || localMutated) {
+      if (!autoMutated) {
+        autoBuyers = { ...autoBuyers };
+        autoMutated = true;
+      }
+      autoBuyers[id] = { ...entry, timer };
+    }
+  }
+
+  return {
+    energy: currentEnergy,
+    gens: gensMutated ? gens : state.gens,
+    autoBuyers: autoMutated ? autoBuyers : state.autoBuyers,
+  };
+};
+
 function reducer(state: State, action: Action): State {
   switch (action.type) {
     case "TICK": {
-      const gain = rateOf(state) * action.dt;
-      if (gain <= 0) return { ...state };
-      const energy = state.energy + gain;
-      return { ...state, energy, totalEnergy: state.totalEnergy + gain };
+      const effects = summarizeEffects({
+        upgrades: state.upgrades,
+        milestones: state.milestones,
+        prestigeUpgrades: state.prestigeUpgrades,
+      });
+      const gain = rateOf(state, effects) * action.dt;
+      const updated = processAutoBuyers(state, state.energy + gain, action.dt);
+      return {
+        ...state,
+        energy: updated.energy,
+        totalEnergy: state.totalEnergy + gain,
+        gens: updated.gens,
+        autoBuyers: updated.autoBuyers,
+      };
     }
     case "CLICK": {
-      const add = CLICK_BASE_GAIN * (1 + state.prestige * 0.1);
+      const effects = summarizeEffects({
+        upgrades: state.upgrades,
+        milestones: state.milestones,
+        prestigeUpgrades: state.prestigeUpgrades,
+      });
+      const prestigeMult = 1 + (state.prestige + effects.prestigeBonus) * 0.1;
+      const add = CLICK_BASE_GAIN * effects.clickMultiplier * prestigeMult;
       return { ...state, energy: state.energy + add, totalEnergy: state.totalEnergy + add };
     }
     case "BUY": {
@@ -73,14 +293,67 @@ function reducer(state: State, action: Action): State {
       if (state.totalEnergy < PRESTIGE_REQ) return state;
       const gained = PRESTIGE_CONVERT(state.totalEnergy);
       return {
+        ...state,
         energy: 0,
         totalEnergy: 0,
         gens: makeDefaultGenState(),
         prestige: state.prestige + gained,
-        lastTs: performance.now(),
+        lastTs: typeof performance !== "undefined" ? performance.now() : Date.now(),
+        autoBuyers: resetAutoBuyerTimers(state.autoBuyers),
       };
     }
-    case "LOAD": return action.payload;
+    case "BUY_UPGRADE": {
+      const def = UPGRADES.find(x => x.id === action.id);
+      if (!def) return state;
+      if (state.upgrades[def.id]) return state;
+      if ((def.unlockAt ?? 0) > state.totalEnergy) return state;
+      if (state.energy < def.cost) return state;
+      const next: State = {
+        ...state,
+        energy: state.energy - def.cost,
+        upgrades: { ...state.upgrades, [def.id]: true },
+      };
+      return applyUnlockEffects(next, def.effects);
+    }
+    case "CLAIM_MILESTONE": {
+      const def = MILESTONES.find(x => x.id === action.id);
+      if (!def) return state;
+      if (state.milestones[def.id]) return state;
+      if (state.totalEnergy < def.threshold) return state;
+      const next: State = {
+        ...state,
+        milestones: { ...state.milestones, [def.id]: true },
+      };
+      return applyUnlockEffects(next, def.effects);
+    }
+    case "BUY_PRESTIGE_UPGRADE": {
+      const def = PRESTIGE_UPGRADES.find(x => x.id === action.id);
+      if (!def) return state;
+      if (state.prestigeUpgrades[def.id]) return state;
+      if ((def.unlockAtPrestige ?? 0) > state.prestige) return state;
+      if ((def.unlockAtTotal ?? 0) > state.totalEnergy) return state;
+      if (state.prestige < def.cost) return state;
+      const next: State = {
+        ...state,
+        prestige: state.prestige - def.cost,
+        prestigeUpgrades: { ...state.prestigeUpgrades, [def.id]: true },
+      };
+      return applyUnlockEffects(next, def.effects);
+    }
+    case "TOGGLE_AUTOBUYER": {
+      const current = state.autoBuyers[action.id];
+      if (!current) return state;
+      if (current.enabled === action.enabled) return state;
+      return {
+        ...state,
+        autoBuyers: {
+          ...state.autoBuyers,
+          [action.id]: { ...current, enabled: action.enabled, timer: action.enabled ? current.timer : 0 },
+        },
+      };
+    }
+    case "LOAD":
+      return ensureAutoBuyersForState(action.payload);
     default: return state;
   }
 }
@@ -93,6 +366,9 @@ type Ctx = {
   canPrestige: boolean;
   offlineGain: number;
   ackOfflineGain: () => void;
+  clickGain: number;
+  prestigeMult: number;
+  effects: EffectSummary;
 };
 const GameCtx = createContext<Ctx | null>(null);
 
@@ -105,12 +381,18 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const latestSnapshotRef = useRef<State>(initial);
   const idleHandleRef = useRef<number | null>(null);
   const [offlineGain, setOfflineGain] = useState(0);
-  const rate = useMemo(() => rateOf(state), [state]);
+  const effects = useMemo(
+    () => summarizeEffects({ upgrades: state.upgrades, milestones: state.milestones, prestigeUpgrades: state.prestigeUpgrades }),
+    [state.upgrades, state.milestones, state.prestigeUpgrades],
+  );
+  const rate = useMemo(() => rateOf(state, effects), [state.gens, state.prestige, effects]);
+  const prestigeMult = useMemo(() => 1 + (state.prestige + effects.prestigeBonus) * 0.1, [state.prestige, effects]);
+  const clickGain = useMemo(() => CLICK_BASE_GAIN * effects.clickMultiplier * prestigeMult, [effects, prestigeMult]);
   const costOf = useCallback((id: string) => {
     const def = GENERATORS.find(g => g.id === id)!;
     const cnt = state.gens[id]?.count ?? 0;
     return nextCost(def, cnt);
-  }, [state]);
+  }, [state.gens]);
   const canPrestige = state.totalEnergy >= PRESTIGE_REQ;
 
   stateRef.current = state;
@@ -175,11 +457,34 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
         if (initializedRef.current) return;
         initializedRef.current = true;
         if (stored) {
-          const loaded: State = {
+          const baseAuto: AutoBuyerState = {};
+          if (stored.autoBuyers) {
+            for (const [id, entry] of Object.entries(stored.autoBuyers)) {
+              if (!entry) continue;
+              const cfg = AUTO_BUYER_CONFIG.get(id);
+              const interval = typeof entry.interval === "number" && entry.interval > 0
+                ? entry.interval
+                : cfg?.interval ?? 5;
+              baseAuto[id] = {
+                enabled: Boolean(entry.enabled),
+                interval,
+                timer: 0,
+              };
+            }
+          }
+
+          let loaded: State = {
             ...initial,
             ...stored,
             gens: { ...makeDefaultGenState(), ...stored.gens },
+            upgrades: { ...makeDefaultUpgradeState(), ...stored.upgrades },
+            milestones: { ...makeDefaultMilestoneState(), ...stored.milestones },
+            prestigeUpgrades: { ...makeDefaultPrestigeUpgradeState(), ...stored.prestigeUpgrades },
+            autoBuyers: baseAuto,
           };
+          loaded = ensureAutoBuyersForState(loaded);
+          loaded = { ...loaded, autoBuyers: resetAutoBuyerTimers(loaded.autoBuyers) };
+
           const rawTs = typeof loaded.lastTs === "number" ? loaded.lastTs : Number.NaN;
           const nowSafe = Number.isFinite(now) ? now : Date.now();
           const legacyThreshold = 10_000_000_000; // ~Sat Nov 20 2286 using ms, plenty above any perf.now values
@@ -188,12 +493,12 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
             : nowSafe;
           const msGap = Math.max(0, nowSafe - normalizedTs);
           const dt = msGap / 1000;
-          const mult = 1 + (loaded.prestige ?? 0) * 0.1;
-          const tempRate = GENERATORS.reduce((sum, g) => {
-            if (g.id === "click") return sum;
-            const c = loaded.gens[g.id]?.count ?? 0;
-            return sum + c * g.baseRate * mult;
-          }, 0);
+          const effectSnapshot = summarizeEffects({
+            upgrades: loaded.upgrades,
+            milestones: loaded.milestones,
+            prestigeUpgrades: loaded.prestigeUpgrades,
+          });
+          const tempRate = rateOf(loaded, effectSnapshot);
           const gain = tempRate * dt;
           loaded.energy += gain;
           loaded.totalEnergy += gain;
@@ -201,7 +506,17 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
           baseDispatch({ type: "LOAD", payload: loaded });
           setOfflineGain(gain > 0 ? gain : 0);
         } else {
-          baseDispatch({ type: "LOAD", payload: { ...initial, gens: makeDefaultGenState(), lastTs: now } });
+          baseDispatch({
+            type: "LOAD",
+            payload: {
+              ...initial,
+              gens: makeDefaultGenState(),
+              upgrades: makeDefaultUpgradeState(),
+              milestones: makeDefaultMilestoneState(),
+              prestigeUpgrades: makeDefaultPrestigeUpgradeState(),
+              lastTs: now,
+            },
+          });
           setOfflineGain(0);
         }
       };
@@ -258,7 +573,21 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return () => cancelAnimationFrame(raf);
   }, []);
 
-  const value = useMemo(() => ({ state, dispatch, rate, costOf, canPrestige, offlineGain, ackOfflineGain }), [state, dispatch, rate, costOf, canPrestige, offlineGain, ackOfflineGain]);
+  const value = useMemo(
+    () => ({
+      state,
+      dispatch,
+      rate,
+      costOf,
+      canPrestige,
+      offlineGain,
+      ackOfflineGain,
+      clickGain,
+      prestigeMult,
+      effects,
+    }),
+    [state, dispatch, rate, costOf, canPrestige, offlineGain, ackOfflineGain, clickGain, prestigeMult, effects],
+  );
   return <GameCtx.Provider value={value}>{children}</GameCtx.Provider>;
 };
 

--- a/src/game/config.ts
+++ b/src/game/config.ts
@@ -1,26 +1,441 @@
 export type GeneratorDef = {
-    id: string;
-    name: string;
-    baseCost: number;
-    costMult: number;     // cost increase per purchase
-    baseRate: number;     // energy/sec per unit
-    unlockAt?: number;    // energy needed to show
-  };
-  
+  id: string;
+  name: string;
+  baseCost: number;
+  costMult: number; // cost increase per purchase
+  baseRate: number; // energy/sec per unit
+  unlockAt?: number; // energy needed to show
+};
+
+export type EffectMultiplierTarget = "click" | "all" | string;
+
+export type MultiplierEffect = {
+  kind: "multiplier";
+  target: EffectMultiplierTarget;
+  value: number;
+};
+
+export type PrestigeBoostEffect = {
+  kind: "prestigeBoost";
+  value: number;
+};
+
+export type AutoBuyerEffect = {
+  kind: "autoBuyer";
+  target: string;
+  interval: number;
+  label: string;
+  description: string;
+};
+
+export type Effect = MultiplierEffect | PrestigeBoostEffect | AutoBuyerEffect;
+
+export type PrestigeUpgradeDef = {
+  id: string;
+  name: string;
+  description: string;
+  cost: number;
+  unlockAtPrestige?: number;
+  unlockAtTotal?: number;
+  effects: Effect[];
+};
+
+export type UpgradeDef = {
+  id: string;
+  name: string;
+  description: string;
+  cost: number;
+  unlockAt?: number;
+  effects: Effect[];
+};
+
+export type MilestoneDef = {
+  id: string;
+  name: string;
+  description: string;
+  threshold: number;
+  effects: Effect[];
+};
+
 export const GENERATORS: GeneratorDef[] = [
-    { id: "click",     name: "Manual Tap", baseCost: 0,        costMult: 1,    baseRate: 0,     unlockAt: 0 }, // special: click-only
-    { id: "spark",     name: "Spark",      baseCost: 10,       costMult: 1.15, baseRate: 0.1,   unlockAt: 0 },
-    { id: "coil",      name: "Coil",       baseCost: 120,      costMult: 1.16, baseRate: 1.25,  unlockAt: 50 },
-    { id: "reactor",   name: "Reactor",    baseCost: 1_800,    costMult: 1.18, baseRate: 12,    unlockAt: 450 },
-    { id: "forge",     name: "Forge",      baseCost: 12_000,   costMult: 1.2,  baseRate: 65,    unlockAt: 3_000 },
-    { id: "singularity", name: "Singularity", baseCost: 150_000, costMult: 1.22, baseRate: 380,  unlockAt: 20_000 },
-    { id: "quantum",   name: "Quantum Core", baseCost: 2_000_000, costMult: 1.24, baseRate: 2_400, unlockAt: 150_000 },
-    { id: "nebula",    name: "Nebula Loom", baseCost: 25_000_000, costMult: 1.26, baseRate: 15_000, unlockAt: 1_000_000 },
-    { id: "ascension", name: "Ascension Gate", baseCost: 350_000_000, costMult: 1.28, baseRate: 110_000, unlockAt: 8_000_000 },
-  ];
-  
-  export const CLICK_BASE_GAIN = 1;              // energy per click
-  export const PRESTIGE_REQ = 100_000;           // min energy for prestige
-  export const PRESTIGE_CONVERT = (energy: number) => Math.floor(Math.sqrt(energy / 1000));
-  export const SAVE_KEY = "idle-ring-save-v1";
+  { id: "click", name: "Manual Tap", baseCost: 0, costMult: 1, baseRate: 0, unlockAt: 0 }, // special: click-only
+  { id: "spark", name: "Spark", baseCost: 10, costMult: 1.15, baseRate: 0.1, unlockAt: 0 },
+  { id: "coil", name: "Coil", baseCost: 120, costMult: 1.16, baseRate: 1.25, unlockAt: 50 },
+  { id: "reactor", name: "Reactor", baseCost: 1_800, costMult: 1.18, baseRate: 12, unlockAt: 450 },
+  { id: "forge", name: "Forge", baseCost: 12_000, costMult: 1.2, baseRate: 65, unlockAt: 3_000 },
+  { id: "singularity", name: "Singularity", baseCost: 150_000, costMult: 1.22, baseRate: 380, unlockAt: 20_000 },
+  { id: "quantum", name: "Quantum Core", baseCost: 2_000_000, costMult: 1.24, baseRate: 2_400, unlockAt: 150_000 },
+  { id: "nebula", name: "Nebula Loom", baseCost: 25_000_000, costMult: 1.26, baseRate: 15_000, unlockAt: 1_000_000 },
+  { id: "ascension", name: "Ascension Gate", baseCost: 350_000_000, costMult: 1.28, baseRate: 110_000, unlockAt: 8_000_000 },
+  { id: "continuum", name: "Continuum Loom", baseCost: 5_000_000_000, costMult: 1.3, baseRate: 650_000, unlockAt: 50_000_000 },
+  { id: "rift", name: "Rift Engine", baseCost: 80_000_000_000, costMult: 1.32, baseRate: 4_500_000, unlockAt: 600_000_000 },
+  { id: "void", name: "Void Conductor", baseCost: 1_200_000_000_000, costMult: 1.34, baseRate: 32_000_000, unlockAt: 7_000_000_000 },
+  { id: "eternium", name: "Eternium Crucible", baseCost: 18_000_000_000_000, costMult: 1.36, baseRate: 240_000_000, unlockAt: 90_000_000_000 },
+  { id: "omega", name: "Omega Archive", baseCost: 270_000_000_000_000, costMult: 1.38, baseRate: 1_800_000_000, unlockAt: 1_200_000_000_000 },
+  { id: "nova", name: "Nova Array", baseCost: 4_000_000_000_000_000, costMult: 1.4, baseRate: 13_000_000_000, unlockAt: 18_000_000_000_000 },
+  { id: "apex", name: "Apex Paradox", baseCost: 65_000_000_000_000_000, costMult: 1.42, baseRate: 95_000_000_000, unlockAt: 300_000_000_000_000 },
+  { id: "eternity", name: "Eternity Gate", baseCost: 1_200_000_000_000_000_000, costMult: 1.44, baseRate: 720_000_000_000, unlockAt: 5_000_000_000_000_000 },
+  { id: "infinity", name: "Infinity Spiral", baseCost: 22_000_000_000_000_000_000, costMult: 1.46, baseRate: 5_800_000_000_000, unlockAt: 90_000_000_000_000_000 },
+  { id: "oblivion", name: "Oblivion Bloom", baseCost: 420_000_000_000_000_000_000, costMult: 1.48, baseRate: 44_000_000_000_000_000, unlockAt: 1_600_000_000_000_000_000 },
+  { id: "eventide", name: "Eventide Singularity", baseCost: 8_000_000_000_000_000_000_000, costMult: 1.5, baseRate: 350_000_000_000_000_000, unlockAt: 28_000_000_000_000_000_000 },
+];
+
+export const UPGRADES: UpgradeDef[] = [
+  {
+    id: "focused-tap",
+    name: "Focused Tap",
+    description: "Double the energy gained from manual tapping. Persists through prestige.",
+    cost: 100,
+    unlockAt: 50,
+    effects: [{ kind: "multiplier", target: "click", value: 2 }],
+  },
+  {
+    id: "resonant-sparks",
+    name: "Resonant Sparks",
+    description: "Sparks generate twice as much energy.",
+    cost: 400,
+    unlockAt: 250,
+    effects: [{ kind: "multiplier", target: "spark", value: 2 }],
+  },
+  {
+    id: "overclocked-grid",
+    name: "Overclocked Grid",
+    description: "Boost all generators by 60%.",
+    cost: 2_500,
+    unlockAt: 1_500,
+    effects: [{ kind: "multiplier", target: "all", value: 1.6 }],
+  },
+  {
+    id: "quantum-supervisor",
+    name: "Quantum Supervisor",
+    description: "Unlock an auto-buyer that purchases Sparks every few seconds.",
+    cost: 12_000,
+    unlockAt: 8_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "spark",
+        interval: 4,
+        label: "Spark Overseer",
+        description: "Automatically buys a Spark every 4s if affordable.",
+      },
+      { kind: "multiplier", target: "spark", value: 1.25 },
+    ],
+  },
+  {
+    id: "stellar-circuitry",
+    name: "Stellar Circuitry",
+    description: "Manual tapping feeds the grid, adding +1 virtual prestige point to production.",
+    cost: 30_000,
+    unlockAt: 20_000,
+    effects: [{ kind: "prestigeBoost", value: 1 }],
+  },
+  {
+    id: "harmonic-forging",
+    name: "Harmonic Forging",
+    description: "Reactors hum in tune with the Forge, supercharging both tiers.",
+    cost: 90_000,
+    unlockAt: 60_000,
+    effects: [
+      { kind: "multiplier", target: "reactor", value: 1.75 },
+      { kind: "multiplier", target: "forge", value: 2.25 },
+    ],
+  },
+  {
+    id: "forge-overseer",
+    name: "Forge Overseer",
+    description: "Deploy an artificer to auto-purchase Forges and push them 50% harder.",
+    cost: 260_000,
+    unlockAt: 180_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "forge",
+        interval: 7,
+        label: "Forge Artificer",
+        description: "Automatically buys a Forge every 7s if affordable.",
+      },
+      { kind: "multiplier", target: "forge", value: 1.5 },
+    ],
+  },
+  {
+    id: "continuum-architects",
+    name: "Continuum Architects",
+    description: "Ascension Gates stabilize the Continuum Loom for triple output.",
+    cost: 4_500_000,
+    unlockAt: 2_500_000,
+    effects: [
+      { kind: "multiplier", target: "ascension", value: 1.8 },
+      { kind: "multiplier", target: "continuum", value: 3 },
+    ],
+  },
+  {
+    id: "void-synthesis",
+    name: "Void Synthesis",
+    description: "Every generator drinks from the void, doubling global output.",
+    cost: 90_000_000,
+    unlockAt: 40_000_000,
+    effects: [{ kind: "multiplier", target: "all", value: 2 }],
+  },
+  {
+    id: "paradox-weaving",
+    name: "Paradox Weaving",
+    description: "Rift Engines and beyond weave paradox threads for massive gains.",
+    cost: 2_400_000_000,
+    unlockAt: 1_000_000_000,
+    effects: [
+      { kind: "multiplier", target: "rift", value: 2.5 },
+      { kind: "multiplier", target: "void", value: 2.5 },
+      { kind: "multiplier", target: "eternium", value: 2.5 },
+    ],
+  },
+  {
+    id: "eventide-dictum",
+    name: "Eventide Dictum",
+    description: "The Eventide Singularity resonates across time, tripling upper-tier output.",
+    cost: 180_000_000_000,
+    unlockAt: 60_000_000_000,
+    effects: [
+      { kind: "multiplier", target: "omega", value: 3 },
+      { kind: "multiplier", target: "nova", value: 3 },
+      { kind: "multiplier", target: "apex", value: 3 },
+      { kind: "multiplier", target: "eternity", value: 3 },
+      { kind: "multiplier", target: "infinity", value: 3 },
+      { kind: "multiplier", target: "oblivion", value: 3 },
+      { kind: "multiplier", target: "eventide", value: 3 },
+    ],
+  },
+];
+
+export const MILESTONES: MilestoneDef[] = [
+  {
+    id: "milestone-first-loop",
+    name: "First Resonance",
+    description: "Reach 500 total energy to harden the ring, granting +25% generator output.",
+    threshold: 500,
+    effects: [{ kind: "multiplier", target: "all", value: 1.25 }],
+  },
+  {
+    id: "milestone-shimmer",
+    name: "Shimmer of Infinity",
+    description: "Accumulate 5,000 total energy to empower prestige by +1.",
+    threshold: 5_000,
+    effects: [{ kind: "prestigeBoost", value: 1 }],
+  },
+  {
+    id: "milestone-automation",
+    name: "Automation Protocol",
+    description: "Hit 25,000 total energy to unlock an auto-buyer for Coils.",
+    threshold: 25_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "coil",
+        interval: 6,
+        label: "Coil Steward",
+        description: "Automatically buys a Coil every 6s if affordable.",
+      },
+    ],
+  },
+  {
+    id: "milestone-stellar-forge",
+    name: "Stellar Forge",
+    description: "Forge 150,000 total energy to supercharge mid-tier structures by 60%.",
+    threshold: 150_000,
+    effects: [
+      { kind: "multiplier", target: "reactor", value: 1.6 },
+      { kind: "multiplier", target: "forge", value: 1.6 },
+      { kind: "multiplier", target: "singularity", value: 1.6 },
+      { kind: "multiplier", target: "quantum", value: 1.6 },
+    ],
+  },
+  {
+    id: "milestone-constellation",
+    name: "Constellation Architects",
+    description: "Harness 1,000,000 total energy to unlock a Nebula Loom auto-buyer and +50% tap power.",
+    threshold: 1_000_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "nebula",
+        interval: 12,
+        label: "Nebula Caretaker",
+        description: "Automatically buys a Nebula Loom every 12s if affordable.",
+      },
+      { kind: "multiplier", target: "click", value: 1.5 },
+    ],
+  },
+  {
+    id: "milestone-astral-horizon",
+    name: "Astral Horizon",
+    description: "Push beyond 5,000,000 total energy to infuse all output by 75%.",
+    threshold: 5_000_000,
+    effects: [{ kind: "multiplier", target: "all", value: 1.75 }],
+  },
+  {
+    id: "milestone-quantum-burst",
+    name: "Quantum Burst",
+    description: "Breach 40,000,000 total energy to add +2 virtual prestige levels to production.",
+    threshold: 40_000_000,
+    effects: [{ kind: "prestigeBoost", value: 2 }],
+  },
+  {
+    id: "milestone-paradox-fleet",
+    name: "Paradox Fleet",
+    description: "Command 3,000,000,000 total energy to unlock a Singularity auto-buyer.",
+    threshold: 3_000_000_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "singularity",
+        interval: 14,
+        label: "Singularity Marshal",
+        description: "Automatically buys a Singularity every 14s if affordable.",
+      },
+    ],
+  },
+  {
+    id: "milestone-continuum-forge",
+    name: "Continuum Forge",
+    description: "Temper 250,000,000,000 total energy to empower end-game structures by 120%.",
+    threshold: 250_000_000_000,
+    effects: [
+      { kind: "multiplier", target: "continuum", value: 2.2 },
+      { kind: "multiplier", target: "rift", value: 2.2 },
+      { kind: "multiplier", target: "void", value: 2.2 },
+      { kind: "multiplier", target: "eternium", value: 2.2 },
+    ],
+  },
+  {
+    id: "milestone-omega-awakening",
+    name: "Omega Awakening",
+    description: "Awaken 20,000,000,000,000 total energy to unlock a Quantum Core auto-buyer and +100% tapping.",
+    threshold: 20_000_000_000_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "quantum",
+        interval: 18,
+        label: "Quantum Custodian",
+        description: "Automatically buys a Quantum Core every 18s if affordable.",
+      },
+      { kind: "multiplier", target: "click", value: 2 },
+    ],
+  },
+  {
+    id: "milestone-eventide-surge",
+    name: "Eventide Surge",
+    description: "Channel 1,200,000,000,000,000,000 total energy to swell the Eventide tiers by 200% and grant a Rift auto-buyer.",
+    threshold: 1_200_000_000_000_000_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "rift",
+        interval: 22,
+        label: "Rift Navigator",
+        description: "Automatically buys a Rift Engine every 22s if affordable.",
+      },
+      { kind: "multiplier", target: "omega", value: 3 },
+      { kind: "multiplier", target: "nova", value: 3 },
+      { kind: "multiplier", target: "apex", value: 3 },
+      { kind: "multiplier", target: "eternity", value: 3 },
+      { kind: "multiplier", target: "infinity", value: 3 },
+      { kind: "multiplier", target: "oblivion", value: 3 },
+      { kind: "multiplier", target: "eventide", value: 3 },
+    ],
+  },
+];
+
+export const PRESTIGE_UPGRADES: PrestigeUpgradeDef[] = [
+  {
+    id: "echoes-of-power",
+    name: "Echoes of Power",
+    description: "Permanent 50% production boost carried across every run.",
+    cost: 3,
+    unlockAtPrestige: 1,
+    effects: [{ kind: "multiplier", target: "all", value: 1.5 }],
+  },
+  {
+    id: "timeless-impulse",
+    name: "Timeless Impulse",
+    description: "Clicks draw strength from prestige, granting +2 virtual levels forever.",
+    cost: 6,
+    unlockAtPrestige: 3,
+    effects: [{ kind: "prestigeBoost", value: 2 }],
+  },
+  {
+    id: "quantum-vaults",
+    name: "Quantum Vaults",
+    description: "Stash power between loops to double all generator output.",
+    cost: 12,
+    unlockAtTotal: 5_000_000,
+    effects: [{ kind: "multiplier", target: "all", value: 2 }],
+  },
+  {
+    id: "automation-matrix",
+    name: "Automation Matrix",
+    description: "An eternal steward auto-buys Void Conductors and Continuum Looms.",
+    cost: 18,
+    unlockAtTotal: 80_000_000,
+    effects: [
+      {
+        kind: "autoBuyer",
+        target: "continuum",
+        interval: 16,
+        label: "Continuum Steward",
+        description: "Automatically buys a Continuum Loom every 16s if affordable.",
+      },
+      {
+        kind: "autoBuyer",
+        target: "void",
+        interval: 28,
+        label: "Void Anchor",
+        description: "Automatically buys a Void Conductor every 28s if affordable.",
+      },
+    ],
+  },
+  {
+    id: "chronal-overflow",
+    name: "Chronal Overflow",
+    description: "Prestige energy compounds quicker: +5 effective prestige levels.",
+    cost: 30,
+    unlockAtTotal: 6_000_000_000,
+    effects: [{ kind: "prestigeBoost", value: 5 }],
+  },
+  {
+    id: "eventide-archive",
+    name: "Eventide Archive",
+    description: "The Eventide Singularity is etched into memory, tripling all Eventide-tier structures permanently.",
+    cost: 55,
+    unlockAtTotal: 500_000_000_000_000,
+    effects: [
+      { kind: "multiplier", target: "omega", value: 3 },
+      { kind: "multiplier", target: "nova", value: 3 },
+      { kind: "multiplier", target: "apex", value: 3 },
+      { kind: "multiplier", target: "eternity", value: 3 },
+      { kind: "multiplier", target: "infinity", value: 3 },
+      { kind: "multiplier", target: "oblivion", value: 3 },
+      { kind: "multiplier", target: "eventide", value: 3 },
+    ],
+  },
+];
+
+export const CLICK_BASE_GAIN = 1; // energy per click
+export const PRESTIGE_REQ = 100_000; // min energy for prestige
+export const PRESTIGE_CONVERT = (energy: number) => Math.floor(Math.sqrt(energy / 1000));
+export const SAVE_KEY = "idle-ring-save-v1";
+
+export const AUTO_BUYER_CONFIG = (() => {
+  const allEffects = [...UPGRADES, ...MILESTONES, ...PRESTIGE_UPGRADES]
+    .flatMap(def => def.effects)
+    .filter((effect): effect is AutoBuyerEffect => effect.kind === "autoBuyer");
+  const map = new Map<string, AutoBuyerEffect>();
+  for (const effect of allEffects) {
+    if (!map.has(effect.target)) {
+      map.set(effect.target, effect);
+    }
+  }
+  return map;
+})();
+
   


### PR DESCRIPTION
## Summary
- expand generators, upgrades, and milestones to stretch progression into late-game tiers and new automation unlocks
- add permanent prestige upgrades with supporting game state, offline handling, and purchase flow
- surface prestige upgrades in the UI and note prestige-gated automation in the automation panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e58c8bbfec832aa7d221e1a440d909