### PR TITLE
Add responsive section tabs and mobile navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
+import { useState } from "react";
 import GeneratorList from "./components/GeneratorList";
 import AutomationPanel from "./components/AutomationPanel";
 import MilestonesPanel from "./components/MilestonesPanel";
@@ -33,12 +34,43 @@ function HUD() {
   );
 }
 
+const sectionOrder = [
+  { id: "constructs", label: "Constructs" },
+  { id: "upgrades", label: "Upgrades" },
+  { id: "milestones", label: "Milestones" },
+  { id: "automation", label: "Automation" },
+  { id: "prestige", label: "Prestige" },
+] as const;
+
+type SectionId = (typeof sectionOrder)[number]["id"];
+
 export default function App() {
+  const [activeSection, setActiveSection] = useState<SectionId>("constructs");
+
+  const renderSectionContent = (sectionId: SectionId) => {
+    switch (sectionId) {
+      case "constructs":
+        return <GeneratorList />;
+      case "upgrades":
+        return <UpgradePanel />;
+      case "milestones":
+        return <MilestonesPanel />;
+      case "automation":
+        return <AutomationPanel />;
+      case "prestige":
+        return <PrestigePanel />;
+      default:
+        return null;
+    }
+  };
+
+  const activeLabel = sectionOrder.find((section) => section.id === activeSection)?.label ?? "";
+
   return (
     <GameProvider>
       <div className="relative min-h-screen overflow-hidden text-slate-100">
         <div className="cosmic-grid pointer-events-none absolute inset-0" aria-hidden />
-        <div className="relative mx-auto flex min-h-screen max-w-screen-md flex-col gap-6 px-4 pb-12 pt-8 sm:px-6">
+        <div className="relative mx-auto flex min-h-screen max-w-screen-md flex-col gap-6 px-4 pb-28 pt-8 sm:px-6 sm:pb-12">
           <header className="relative mb-4 flex flex-col gap-2 text-center">
             <motion.h1
               className="text-4xl font-bold tracking-wide text-indigo-200 drop-shadow"
@@ -72,72 +104,107 @@ export default function App() {
             </div>
           </motion.section>
 
-          <motion.section
-            className="rounded-3xl border border-sky-500/30 bg-slate-900/55 p-5 shadow-2xl shadow-sky-900/25 backdrop-blur card-glow"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, ease: "easeOut", delay: 0.05 }}
-          >
-            <h2 className="font-semibold uppercase tracking-wider text-sky-200">Constructs</h2>
-            <div className="mt-4">
-              <GeneratorList />
-            </div>
-          </motion.section>
+          <div className="relative">
+            <nav className="hidden items-center justify-center gap-2 rounded-full border border-indigo-500/30 bg-slate-900/70 p-1 shadow-lg shadow-indigo-900/25 backdrop-blur sm:flex">
+              {sectionOrder.map((section) => (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => setActiveSection(section.id)}
+                  className={`relative rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
+                    activeSection === section.id
+                      ? "bg-indigo-500/30 text-indigo-100 shadow-inner shadow-indigo-500/20"
+                      : "text-slate-300/70 hover:text-slate-100"
+                  }`}
+                  aria-pressed={activeSection === section.id}
+                >
+                  {section.label}
+                  {activeSection === section.id && (
+                    <span className="pointer-events-none absolute inset-x-2 -bottom-1 h-px bg-gradient-to-r from-transparent via-indigo-300 to-transparent" />
+                  )}
+                </button>
+              ))}
+            </nav>
 
-          <motion.section
-            className="rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-5 shadow-2xl shadow-emerald-900/20 backdrop-blur card-glow"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, ease: "easeOut", delay: 0.08 }}
-          >
-            <h2 className="font-semibold uppercase tracking-wider text-emerald-200">Upgrades</h2>
-            <div className="mt-4">
-              <UpgradePanel />
-            </div>
-          </motion.section>
-
-          <motion.section
-            className="rounded-3xl border border-fuchsia-500/30 bg-fuchsia-500/10 p-5 shadow-2xl shadow-fuchsia-900/20 backdrop-blur card-glow"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, ease: "easeOut", delay: 0.1 }}
-          >
-            <h2 className="font-semibold uppercase tracking-wider text-fuchsia-200">Milestones</h2>
-            <div className="mt-4">
-              <MilestonesPanel />
-            </div>
-          </motion.section>
-
-          <motion.section
-            className="rounded-3xl border border-cyan-500/30 bg-cyan-500/10 p-5 shadow-2xl shadow-cyan-900/20 backdrop-blur card-glow"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, ease: "easeOut", delay: 0.12 }}
-          >
-            <h2 className="font-semibold uppercase tracking-wider text-cyan-200">Automation</h2>
-            <div className="mt-4">
-              <AutomationPanel />
-            </div>
-          </motion.section>
-
-          <motion.section
-            className="rounded-3xl border border-amber-500/30 bg-amber-500/10 p-5 shadow-2xl shadow-amber-900/20 backdrop-blur card-glow"
-            initial={{ opacity: 0, y: 30 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, ease: "easeOut", delay: 0.14 }}
-          >
-            <PrestigePanel />
-          </motion.section>
+            <AnimatePresence mode="wait">
+              {activeSection === "prestige" ? (
+                <motion.div
+                  key="prestige"
+                  initial={{ opacity: 0, y: 30 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 20 }}
+                  transition={{ duration: 0.35, ease: "easeOut" }}
+                  className="mt-6"
+                >
+                  {renderSectionContent(activeSection)}
+                </motion.div>
+              ) : (
+                <motion.section
+                  key={activeSection}
+                  initial={{ opacity: 0, y: 30 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: 20 }}
+                  transition={{ duration: 0.35, ease: "easeOut" }}
+                  className={`mt-6 rounded-3xl border p-5 shadow-2xl backdrop-blur card-glow ${
+                    activeSection === "constructs"
+                      ? "border-sky-500/30 bg-slate-900/55 shadow-sky-900/25"
+                      : activeSection === "upgrades"
+                      ? "border-emerald-500/30 bg-emerald-500/10 shadow-emerald-900/20"
+                      : activeSection === "milestones"
+                      ? "border-fuchsia-500/30 bg-fuchsia-500/10 shadow-fuchsia-900/20"
+                      : "border-cyan-500/30 bg-cyan-500/10 shadow-cyan-900/20"
+                  }`}
+                >
+                  <h2
+                    className={`font-semibold uppercase tracking-wider ${
+                      activeSection === "constructs"
+                        ? "text-sky-200"
+                        : activeSection === "upgrades"
+                        ? "text-emerald-200"
+                        : activeSection === "milestones"
+                        ? "text-fuchsia-200"
+                        : "text-cyan-200"
+                    }`}
+                  >
+                    {activeLabel}
+                  </h2>
+                  <div className="mt-4">{renderSectionContent(activeSection)}</div>
+                </motion.section>
+              )}
+            </AnimatePresence>
+          </div>
 
           <motion.footer
             className="mt-4 text-center text-xs uppercase tracking-[0.4em] text-slate-300/60"
             initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: 0.5, duration: 0.5 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.5, duration: 0.5 }}
           >
             tip: close the tab and come back later—offline progress is saved.
           </motion.footer>
         </div>
+
+        <nav className="sm:hidden">
+          <div className="fixed bottom-4 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 px-4">
+            <div className="flex items-stretch justify-between gap-1 rounded-3xl border border-indigo-500/40 bg-slate-950/80 px-2 py-2 shadow-2xl shadow-indigo-900/40 backdrop-blur-xl">
+              {sectionOrder.map((section) => (
+                <button
+                  key={section.id}
+                  type="button"
+                  onClick={() => setActiveSection(section.id)}
+                  className={`flex flex-1 flex-col items-center justify-center rounded-2xl px-2 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
+                    activeSection === section.id
+                      ? "bg-indigo-500/25 text-indigo-100 shadow-inner shadow-indigo-500/20"
+                      : "text-slate-300/70 hover:text-slate-100"
+                  }`}
+                  aria-pressed={activeSection === section.id}
+                >
+                  {section.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </nav>
       </div>
     </GameProvider>
   );


### PR DESCRIPTION
## Summary
- replace the long vertical list of panels with a tabbed section switcher on larger screens
- add a native-style bottom navigation bar for mobile to make section access faster
- preserve existing section visuals while animating transitions between the active panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61f961d24832aa31d3ff492935728