### PR TITLE
Improve construct insights and mobile navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "framer-motion": "^12.23.22",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -3645,6 +3646,15 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "framer-motion": "^12.23.22",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
+import type { IconType } from "react-icons";
+import { FiCpu, FiFlag, FiGrid, FiStar, FiTrendingUp } from "react-icons/fi";
 import GeneratorList from "./components/GeneratorList";
 import AutomationPanel from "./components/AutomationPanel";
 import MilestonesPanel from "./components/MilestonesPanel";
@@ -43,6 +45,14 @@ const sectionOrder = [
 ] as const;
 
 type SectionId = (typeof sectionOrder)[number]["id"];
+
+const sectionIcons: Record<SectionId, IconType> = {
+  constructs: FiGrid,
+  upgrades: FiTrendingUp,
+  milestones: FiFlag,
+  automation: FiCpu,
+  prestige: FiStar,
+};
 
 export default function App() {
   const [activeSection, setActiveSection] = useState<SectionId>("constructs");
@@ -187,21 +197,30 @@ export default function App() {
         <nav className="sm:hidden">
           <div className="fixed bottom-4 left-1/2 z-50 w-full max-w-sm -translate-x-1/2 px-4">
             <div className="flex items-stretch justify-between gap-1 rounded-3xl border border-indigo-500/40 bg-slate-950/80 px-2 py-2 shadow-2xl shadow-indigo-900/40 backdrop-blur-xl">
-              {sectionOrder.map((section) => (
-                <button
-                  key={section.id}
-                  type="button"
-                  onClick={() => setActiveSection(section.id)}
-                  className={`flex flex-1 flex-col items-center justify-center rounded-2xl px-2 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
-                    activeSection === section.id
-                      ? "bg-indigo-500/25 text-indigo-100 shadow-inner shadow-indigo-500/20"
-                      : "text-slate-300/70 hover:text-slate-100"
-                  }`}
-                  aria-pressed={activeSection === section.id}
-                >
-                  {section.label}
-                </button>
-              ))}
+              {sectionOrder.map((section) => {
+                const Icon = sectionIcons[section.id];
+                return (
+                  <button
+                    key={section.id}
+                    type="button"
+                    onClick={() => setActiveSection(section.id)}
+                    className={`flex flex-1 flex-col items-center justify-center rounded-2xl px-2 py-1.5 text-[11px] font-semibold uppercase tracking-[0.3em] transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
+                      activeSection === section.id
+                        ? "bg-indigo-500/25 text-indigo-100 shadow-inner shadow-indigo-500/20"
+                        : "text-slate-300/70 hover:text-slate-100"
+                    }`}
+                    aria-pressed={activeSection === section.id}
+                  >
+                    <Icon
+                      aria-hidden
+                      className={`text-lg ${
+                        activeSection === section.id ? "text-indigo-100" : "text-slate-300/80"
+                      }`}
+                    />
+                    <span className="sr-only">{section.label}</span>
+                  </button>
+                );
+              })}
             </div>
           </div>
         </nav>

--- a/src/components/GeneratorList.tsx
+++ b/src/components/GeneratorList.tsx
@@ -3,16 +3,56 @@ import { GENERATORS } from "../game/config";
 import { useGame } from "../game/GameProvider";
 import { format } from "../utils/format";
 
+const formatMultiplier = (value: number) => `${value.toFixed(2)}x`;
+
+const formatPrecise = (value: number) => {
+  if (!Number.isFinite(value)) return "0";
+  const abs = Math.abs(value);
+  const decimals = abs >= 100 ? 0 : abs >= 10 ? 1 : 2;
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+};
+
 export default function GeneratorList() {
-  const { state, dispatch, costOf } = useGame();
+  const { state, dispatch, costOf, effects, prestigeMult, rate } = useGame();
+
+  const globalMultiplier = effects.globalGeneratorMultiplier;
+  const prestigeStacks = state.prestige + effects.prestigeBonus;
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-sky-400/20 bg-slate-900/60 p-4 shadow-lg shadow-sky-900/20 backdrop-blur">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300/70">Insight Flow</div>
+            <div className="text-lg font-semibold text-sky-100">{format(rate)} insight / sec</div>
+          </div>
+          <dl className="grid grid-cols-2 gap-3 text-xs text-slate-200/80 sm:text-right">
+            <div>
+              <dt className="uppercase tracking-[0.25em] text-slate-400">Prestige Bonus</dt>
+              <dd className="font-semibold text-slate-100">{formatPrecise(prestigeStacks)} pts → {formatMultiplier(prestigeMult)}</dd>
+            </div>
+            <div>
+              <dt className="uppercase tracking-[0.25em] text-slate-400">Global Construct Boost</dt>
+              <dd className="font-semibold text-slate-100">{formatMultiplier(globalMultiplier)}</dd>
+            </div>
+          </dl>
+        </div>
+        <p className="mt-3 text-xs leading-relaxed text-slate-300/80">
+          Insight per second is the sum of each construct: <span className="font-semibold text-slate-100">count × base rate × global boosts × construct boosts × prestige multiplier</span>.
+        </p>
+      </div>
+
       {GENERATORS.filter(g => (g.unlockAt ?? 0) <= state.totalEnergy).map(g => {
         if (g.id === "click") return null;
         const cost = costOf(g.id);
         const count = state.gens[g.id]?.count ?? 0;
         const canBuy = state.energy >= cost;
+        const perConstructMultiplier = globalMultiplier * (effects.generatorMultipliers[g.id] ?? 1) * prestigeMult;
+        const perConstructRate = g.baseRate * perConstructMultiplier;
+        const totalRate = perConstructRate * count;
         return (
           <motion.div
             key={g.id}
@@ -24,6 +64,19 @@ export default function GeneratorList() {
             <div>
               <div className="font-semibold text-sky-200">{g.name}</div>
               <div className="text-[11px] uppercase tracking-[0.25em] text-slate-300/70">Owned: {count}</div>
+              <div className="mt-3 space-y-1 text-xs text-slate-200">
+                <div className="flex items-center justify-between">
+                  <span>Per construct</span>
+                  <span className="font-semibold text-sky-100">{format(perConstructRate)} / sec</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Total contribution</span>
+                  <span className="font-semibold text-sky-100">{format(totalRate)} / sec</span>
+                </div>
+                <div className="text-[11px] uppercase tracking-[0.2em] text-slate-400">
+                  {formatPrecise(g.baseRate)} base × {formatMultiplier(globalMultiplier)} global × {formatMultiplier(effects.generatorMultipliers[g.id] ?? 1)} construct × {formatMultiplier(prestigeMult)} prestige
+                </div>
+              </div>
             </div>
             <motion.button
               whileTap={canBuy ? { scale: 0.94 } : undefined}


### PR DESCRIPTION
## Summary
- replace the mobile navigation tabs with compact icons for easier access on small screens
- surface insight-per-second formulas and per-construct breakdowns in the constructs panel for better transparency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6225f7a70832a99b345c692e69c83