### PR TITLE
Optimize game provider calculations and modularize state logic

### DIFF
--- a/src/game/autoBuyers.ts
+++ b/src/game/autoBuyers.ts
@@ -1,0 +1,123 @@
+import type { Effect } from "./config";
+import { MILESTONES, UPGRADES } from "./config";
+import { getGeneratorDef, nextCost } from "./economy";
+import type { AutoBuyerState, BaseState } from "./types";
+
+export const applyUnlockEffects = (state: BaseState, effects: Effect[]): BaseState => {
+  let autoBuyers = state.autoBuyers;
+  let changed = false;
+  for (const effect of effects) {
+    if (effect.kind !== "autoBuyer") continue;
+    const existing = autoBuyers[effect.target];
+    const nextEntry = {
+      enabled: existing?.enabled ?? false,
+      timer: existing?.enabled ? existing.timer : 0,
+      interval: effect.interval,
+    };
+    if (!existing || existing.interval !== effect.interval || existing.timer !== nextEntry.timer) {
+      if (!changed) {
+        autoBuyers = { ...autoBuyers };
+        changed = true;
+      }
+      autoBuyers[effect.target] = nextEntry;
+    }
+  }
+
+  if (!changed) return state;
+  return { ...state, autoBuyers };
+};
+
+export const ensureAutoBuyersForState = (state: BaseState): BaseState => {
+  let current = state;
+  for (const upgrade of UPGRADES) {
+    if (current.upgrades[upgrade.id]) {
+      current = applyUnlockEffects(current, upgrade.effects);
+    }
+  }
+  for (const milestone of MILESTONES) {
+    if (current.milestones[milestone.id]) {
+      current = applyUnlockEffects(current, milestone.effects);
+    }
+  }
+  return current;
+};
+
+export const resetAutoBuyerTimers = (autoBuyers: AutoBuyerState): AutoBuyerState => {
+  const entries = Object.entries(autoBuyers);
+  if (entries.length === 0) return autoBuyers;
+  const next: AutoBuyerState = {};
+  for (const [id, entry] of entries) {
+    next[id] = { ...entry, timer: 0 };
+  }
+  return next;
+};
+
+export const processAutoBuyers = (
+  state: BaseState,
+  energy: number,
+  dt: number,
+): { energy: number; gens: BaseState["gens"]; autoBuyers: AutoBuyerState } => {
+  if (Object.keys(state.autoBuyers).length === 0) {
+    return { energy, gens: state.gens, autoBuyers: state.autoBuyers };
+  }
+
+  let currentEnergy = energy;
+  let gens = state.gens;
+  let autoBuyers: AutoBuyerState = state.autoBuyers;
+  let autoMutated = false;
+  let gensMutated = false;
+
+  for (const [id, entry] of Object.entries(state.autoBuyers)) {
+    if (!entry || !entry.enabled) {
+      if (entry && entry.timer !== 0) {
+        if (!autoMutated) {
+          autoBuyers = { ...autoBuyers };
+          autoMutated = true;
+        }
+        autoBuyers[id] = { ...entry, timer: 0 };
+      }
+      continue;
+    }
+
+    const def = getGeneratorDef(id);
+    if (!def) continue;
+
+    let timer = entry.timer + dt;
+    let workingEnergy = currentEnergy;
+    let workingGens = gens;
+    let localMutated = false;
+
+    while (timer >= entry.interval) {
+      const currentCount = workingGens[id]?.count ?? 0;
+      const cost = nextCost(id, currentCount);
+      if (workingEnergy < cost) break;
+      if (!localMutated) {
+        workingGens = { ...workingGens };
+        localMutated = true;
+      }
+      workingGens[id] = { count: currentCount + 1 };
+      workingEnergy -= cost;
+      timer -= entry.interval;
+    }
+
+    if (localMutated) {
+      gens = workingGens;
+      gensMutated = true;
+      currentEnergy = workingEnergy;
+    }
+
+    if (timer !== entry.timer || localMutated) {
+      if (!autoMutated) {
+        autoBuyers = { ...autoBuyers };
+        autoMutated = true;
+      }
+      autoBuyers[id] = { ...entry, timer };
+    }
+  }
+
+  return {
+    energy: currentEnergy,
+    gens: gensMutated ? gens : state.gens,
+    autoBuyers: autoMutated ? autoBuyers : state.autoBuyers,
+  };
+};

--- a/src/game/economy.ts
+++ b/src/game/economy.ts
@@ -1,0 +1,73 @@
+import { CLICK_BASE_GAIN, GENERATORS } from "./config";
+import type { BaseState, EffectSummary } from "./types";
+
+const generatorMap = new Map(GENERATORS.map((generator) => [generator.id, generator]));
+
+export const getGeneratorDef = (id: string) => generatorMap.get(id);
+
+export const nextCost = (id: string, count: number): number => {
+  const def = generatorMap.get(id);
+  if (!def) {
+    throw new Error(`Unknown generator id: ${id}`);
+  }
+  return Math.ceil(def.baseCost * Math.pow(def.costMult, count));
+};
+
+let cachedPrestige = { prestige: Number.NaN, bonus: Number.NaN, value: 1 };
+
+const getPrestigeMultiplier = (prestige: number, bonus: number): number => {
+  if (cachedPrestige.prestige === prestige && cachedPrestige.bonus === bonus) {
+    return cachedPrestige.value;
+  }
+  const value = 1 + (prestige + bonus) * 0.1;
+  cachedPrestige = { prestige, bonus, value };
+  return value;
+};
+
+export const calculatePrestigeMultiplier = (state: BaseState, effects: EffectSummary): number =>
+  getPrestigeMultiplier(state.prestige, effects.prestigeBonus);
+
+let cachedRate = {
+  gensRef: null as BaseState["gens"] | null,
+  prestigeMult: Number.NaN,
+  effectsRef: null as EffectSummary | null,
+  value: 0,
+};
+
+export const calculateRate = (state: BaseState, effects: EffectSummary): number => {
+  const prestigeMult = getPrestigeMultiplier(state.prestige, effects.prestigeBonus);
+  if (
+    cachedRate.gensRef === state.gens &&
+    cachedRate.effectsRef === effects &&
+    cachedRate.prestigeMult === prestigeMult
+  ) {
+    return cachedRate.value;
+  }
+
+  let sum = 0;
+  for (const generator of GENERATORS) {
+    if (generator.id === "click") continue;
+    const count = state.gens[generator.id]?.count ?? 0;
+    if (count === 0) continue;
+    const mult = effects.globalGeneratorMultiplier * (effects.generatorMultipliers[generator.id] ?? 1);
+    sum += count * generator.baseRate * mult * prestigeMult;
+  }
+
+  cachedRate = { gensRef: state.gens, effectsRef: effects, prestigeMult, value: sum };
+  return sum;
+};
+
+let cachedClick = {
+  effectsRef: null as EffectSummary | null,
+  prestigeMult: Number.NaN,
+  value: 0,
+};
+
+export const calculateClickGain = (effects: EffectSummary, prestigeMult: number): number => {
+  if (cachedClick.effectsRef === effects && cachedClick.prestigeMult === prestigeMult) {
+    return cachedClick.value;
+  }
+  const value = CLICK_BASE_GAIN * effects.clickMultiplier * prestigeMult;
+  cachedClick = { effectsRef: effects, prestigeMult, value };
+  return value;
+};

--- a/src/game/effects.ts
+++ b/src/game/effects.ts
@@ -1,0 +1,72 @@
+import type { Effect } from "./config";
+import { MILESTONES, UPGRADES } from "./config";
+import type { EffectSummary, MilestoneState, UpgradeState } from "./types";
+
+const effectCache = new WeakMap<UpgradeState, WeakMap<MilestoneState, EffectSummary>>();
+
+const cloneSummary = (summary: EffectSummary): EffectSummary => ({
+  clickMultiplier: summary.clickMultiplier,
+  globalGeneratorMultiplier: summary.globalGeneratorMultiplier,
+  generatorMultipliers: { ...summary.generatorMultipliers },
+  prestigeBonus: summary.prestigeBonus,
+});
+
+const freezeSummary = (summary: EffectSummary): EffectSummary => {
+  Object.freeze(summary.generatorMultipliers);
+  return Object.freeze(summary);
+};
+
+const buildSummary = (flags: { upgrades: UpgradeState; milestones: MilestoneState }): EffectSummary => {
+  const summary: EffectSummary = {
+    clickMultiplier: 1,
+    globalGeneratorMultiplier: 1,
+    generatorMultipliers: {},
+    prestigeBonus: 0,
+  };
+
+  const effects: Effect[] = [];
+  for (const upgrade of UPGRADES) {
+    if (flags.upgrades[upgrade.id]) {
+      effects.push(...upgrade.effects);
+    }
+  }
+  for (const milestone of MILESTONES) {
+    if (flags.milestones[milestone.id]) {
+      effects.push(...milestone.effects);
+    }
+  }
+
+  for (const effect of effects) {
+    if (effect.kind === "multiplier") {
+      if (effect.target === "click") {
+        summary.clickMultiplier *= effect.value;
+      } else if (effect.target === "all") {
+        summary.globalGeneratorMultiplier *= effect.value;
+      } else {
+        summary.generatorMultipliers[effect.target] =
+          (summary.generatorMultipliers[effect.target] ?? 1) * effect.value;
+      }
+    } else if (effect.kind === "prestigeBoost") {
+      summary.prestigeBonus += effect.value;
+    }
+  }
+
+  return summary;
+};
+
+export const getEffectSummary = (upgrades: UpgradeState, milestones: MilestoneState): EffectSummary => {
+  let milestoneCache = effectCache.get(upgrades);
+  if (!milestoneCache) {
+    milestoneCache = new WeakMap<MilestoneState, EffectSummary>();
+    effectCache.set(upgrades, milestoneCache);
+  }
+
+  let summary = milestoneCache.get(milestones);
+  if (!summary) {
+    const built = freezeSummary(cloneSummary(buildSummary({ upgrades, milestones })));
+    summary = built;
+    milestoneCache.set(milestones, summary);
+  }
+
+  return summary;
+};

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,0 +1,44 @@
+import { GENERATORS, MILESTONES, UPGRADES } from "./config";
+
+export type GenState = Record<string, { count: number }>;
+export type UpgradeState = Record<string, boolean>;
+export type MilestoneState = Record<string, boolean>;
+export type AutoBuyerState = Record<string, { enabled: boolean; interval: number; timer: number }>;
+
+export type BaseState = {
+  energy: number;
+  totalEnergy: number;
+  gens: GenState;
+  prestige: number;
+  lastTs: number;
+  upgrades: UpgradeState;
+  milestones: MilestoneState;
+  autoBuyers: AutoBuyerState;
+};
+
+export type EffectSummary = {
+  clickMultiplier: number;
+  globalGeneratorMultiplier: number;
+  generatorMultipliers: Record<string, number>;
+  prestigeBonus: number;
+};
+
+export const makeDefaultGenState = (): GenState =>
+  Object.fromEntries(GENERATORS.map((generator) => [generator.id, { count: 0 }]));
+
+export const makeDefaultUpgradeState = (): UpgradeState =>
+  Object.fromEntries(UPGRADES.map((upgrade) => [upgrade.id, false]));
+
+export const makeDefaultMilestoneState = (): MilestoneState =>
+  Object.fromEntries(MILESTONES.map((milestone) => [milestone.id, false]));
+
+export const createInitialState = (): BaseState => ({
+  energy: 0,
+  totalEnergy: 0,
+  gens: makeDefaultGenState(),
+  prestige: 0,
+  lastTs: Date.now(),
+  upgrades: makeDefaultUpgradeState(),
+  milestones: makeDefaultMilestoneState(),
+  autoBuyers: {},
+});


### PR DESCRIPTION
## Summary
- extract shared game state types and helpers into dedicated modules to simplify the GameProvider
- memoize effect summaries, production rates, and click gains to avoid redundant per-frame calculations
- streamline auto-buyer management and loading logic while preserving persistence behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e653eba5b4832aad66f3c67ebbd19a